### PR TITLE
Fixing printing of subsample_count

### DIFF
--- a/mp4tree.c
+++ b/mp4tree.c
@@ -506,14 +506,13 @@ mp4tree_box_senc_print(
         if (flags & 0x000002)
         {
             uint32_t sub_sample_count = get_u16(p);
-            printf("%s  Subsample Count: %u\n", indent(depth+1, 0), sample_count);
+            printf("%s  Subsample Count: %u\n", indent(depth+1, 0), sub_sample_count);
             p += 2;
-            printf("%s Subsample: %u\n", indent(depth+1, 1), j);
-            printf("%s  BytesOfClear  BytesOfProtectedData\n", indent(depth+2, 0));
+            printf("%s  Subsample  BytesOfClear  BytesOfProtectedData\n", indent(depth+2, 0));
             for (j = 0; j < sub_sample_count; j++)
             {
-                printf("%s    %3u               %5u  \n",
-                       indent(depth+2, 0), get_u16(p), get_u32(p+2));
+                printf("%s  %8d:   %3u               %5u  \n",
+                       indent(depth+2, 0), j, get_u16(p), get_u32(p+2));
 
                 p +=6;
             }


### PR DESCRIPTION
Subsample count was mixed up with sample count.

Also the previously highest subsample index was always printed as the current subsample number, e.g. 3 instead of 0.

Fixed formatting a bit.

The output now looks like this:

```
|  |  +--- Length: 5676 Type: senc
|  |  |    Version:      0
|  |  |    Flags:        0x000002
|  |  |    Sample Count: 200
|  |  |  + Sample:   0
|  |  |  |    IV:      b8 5a 75 f4 ff d6 ff 51
|  |  |  |    Subsample Count: 5
|  |  |  |  |    Subsample  BytesOfClear  BytesOfProtectedData
|  |  |  |  |           0:     6                   0  
|  |  |  |  |           1:    47                   0  
|  |  |  |  |           2:     9                   0  
|  |  |  |  |           3:    46                   0  
|  |  |  |  |           4:     5               31304  
|  |  |  + Sample:   1
|  |  |  |    IV:      b8 5a 75 f4 ff d6 ff 52
|  |  |  |    Subsample Count: 3
|  |  |  |  |    Subsample  BytesOfClear  BytesOfProtectedData
|  |  |  |  |           0:     6                   0  
|  |  |  |  |           1:    32                   0  
|  |  |  |  |           2:     5               19210  
|  |  |  + Sample:   2
|  |  |  |    IV:      b8 5a 75 f4 ff d6 ff 53
|  |  |  |    Subsample Count: 3
|  |  |  |  |    Subsample  BytesOfClear  BytesOfProtectedData
|  |  |  |  |           0:     6                   0  
|  |  |  |  |           1:    32                   0  
|  |  |  |  |           2:     5                9920  
```

@edgeware/yankee 
