### PR TITLE
Dump H264 SEI NAL units

### DIFF
--- a/mp4tree.c
+++ b/mp4tree.c
@@ -350,6 +350,7 @@ mp4tree_box_mdat_h264_nal_print(
             break;
         case 6:
             typestr = "SEI";
+            hexdump = true;
             break;
         case 7:
             typestr = "SPS";


### PR DESCRIPTION
SEI is in the same boat as SPS and PPS, which are basically metadata and short enough that hexdumping is not a bad idea.